### PR TITLE
feat: Extract metadata from Error instead of ctx

### DIFF
--- a/context.go
+++ b/context.go
@@ -31,8 +31,7 @@ func WithMetadata(ctx context.Context, data map[string]interface{}) context.Cont
 }
 
 // Metadata pulls out all the metadata known by this package as a
-// map[key]value from the given error. Extracts the metadata of the
-// *rogerr.Error that was wrapped closest to the root error.
+// map[key]value from the given error.
 func Metadata(err error) map[string]interface{} {
 	rErr := &Error{}
 


### PR DESCRIPTION
Full disclosure, this works 'magically' because we keep a *reference* to the map of metadata instead of recreating each time for each new context. This feels a bit wrong, but I cannot figure out why this would be a bad idea... That's a problem for future me.