### PR TITLE
Clean up code based on feedback and a good night's sleep

### DIFF
--- a/context.go
+++ b/context.go
@@ -33,7 +33,7 @@ func WithMetadata(ctx context.Context, data map[string]interface{}) context.Cont
 // Metadata pulls out all the metadata known by this package as a
 // map[key]value from the given error.
 func Metadata(err error) map[string]interface{} {
-	rErr := &Error{}
+	rErr := &rError{}
 
 	// Yes, that's a double pointer. The error type is a struct pointer, and
 	// errors.As requires a pointer to a type that implements the error

--- a/context_test.go
+++ b/context_test.go
@@ -84,8 +84,8 @@ func TestMetadata(t *testing.T) {
 	t.Run("integration test", func(t *testing.T) {
 		/*
 			This test case reflects the real world a bit more, in particular:
-			- The rogerr.Error type might be wrapped multiple kinds
-				- by another rogerr.Error
+			- The rogerr.rError type might be wrapped multiple kinds
+				- by another rogerr.rError
 					- simple wrap-and-return
 					- the programmer may choose to add context data *after* they know there's an error, and then wrap the error with a different context.
 				- by other errors like fmt.Errorf or errors.New
@@ -104,7 +104,7 @@ func TestMetadata(t *testing.T) {
 			return fmt.Errorf("ooi: %w", fourthWrap)
 		}
 
-		var err error = complicatedErrorFlow() // long-form variable declaration to ensure interface adherence via the compiler
+		err := complicatedErrorFlow()
 
 		md := rogerr.Metadata(err)
 		if got := len(md); got != len(metadata)+1 /* metadatum adds one */ {

--- a/error.go
+++ b/error.go
@@ -5,20 +5,14 @@ import (
 	"fmt"
 )
 
-// Error allows you to specify certain properties of an error.
-// Setting Panic to true indicates that the application was not able to
-// gracefully handle an error or panic that occurred in the system.
-type Error struct {
-	Unhandled bool
-	Panic     bool
-
+type rError struct {
 	err error
 	ctx context.Context
 	msg string
 }
 
-// Error returns the message of the error, along with any wrapped error messages.
-func (e *Error) Error() string {
+// Error returns the message of the rError, along with any wrapped error messages.
+func (e *rError) Error() string {
 	if e.err == nil && e.msg == "" {
 		return "unknown error"
 	}
@@ -32,7 +26,7 @@ func (e *Error) Error() string {
 }
 
 // Unwrap is the conventional method for getting the underlying error of an error.
-func (e *Error) Unwrap() error {
+func (e *rError) Unwrap() error {
 	if e == nil {
 		return nil
 	}
@@ -44,11 +38,11 @@ func (e *Error) Unwrap() error {
 // for this function to return a non-nil error.
 // Any attached diagnostic data from this ctx will be preserved should you
 // pass the returned error further up the stack.
-func Wrap(ctx context.Context, err error, msgAndFmtArgs ...interface{}) *Error {
+func Wrap(ctx context.Context, err error, msgAndFmtArgs ...interface{}) error {
 	if ctx == nil && err == nil && msgAndFmtArgs == nil {
 		return nil
 	}
-	e := &Error{err: err, ctx: ctx}
+	e := &rError{err: err, ctx: ctx}
 
 	if l := len(msgAndFmtArgs); l > 0 {
 		if msg, ok := msgAndFmtArgs[0].(string); ok {

--- a/error_test.go
+++ b/error_test.go
@@ -80,7 +80,7 @@ func TestWrap(t *testing.T) {
 			if tc.msg != "" || tc.args != nil {
 				tc.args = append([]interface{}{tc.msg}, tc.args...)
 			}
-			wrapped := Wrap(tc.ctx, tc.err, tc.args...)
+			wrapped := Wrap(tc.ctx, tc.err, tc.args...).(*rError)
 			if wrapped == nil {
 				t.Fatalf("got nil err")
 			}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,41 @@
+package rogerr_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kinbiko/rogerr"
+)
+
+func ExampleWrap() {
+	someFuncWithAProblem := func(ctx context.Context) error {
+		return fmt.Errorf("some low level err")
+	}
+
+	someFuncThatWrapsWithRogerr := func(ctx context.Context) error {
+		// Attach some projectID to the context as structured metadata
+		ctx = rogerr.WithMetadatum(ctx, "projectID", 123)
+
+		err := someFuncWithAProblem(ctx)
+		if err != nil {
+			return rogerr.Wrap(ctx, err, "wrap args")
+		}
+		return nil
+	}
+
+	someFuncThatWrapsARogerrError := func(ctx context.Context) error {
+		err := someFuncThatWrapsWithRogerr(ctx)
+		if err != nil {
+			return fmt.Errorf("wrap with fmt: %w", err)
+		}
+		return nil
+	}
+
+	err := someFuncThatWrapsARogerrError(context.Background())
+	md := rogerr.Metadata(err)
+	fmt.Println(err.Error())     // error message should be cleanly wrapped
+	fmt.Println(md["projectID"]) // structured metadata should be available
+	//output:
+	// wrap with fmt: wrap args: some low level err
+	// 123
+}


### PR DESCRIPTION
Strictly speaking this is a breaking change as we're removing the `Error` type from the public API.
However nobody is using this package so I choose to believe it's OK to keep not v2 this change.

- Removes the `Error` type from the public API
  - better maintainability
  - nobody will create an error from this package in an incorrect manner
- Adds documentation in the form of a runnable example.
